### PR TITLE
Fix device mismatch issue after 10% optimization

### DIFF
--- a/learn_delta.py
+++ b/learn_delta.py
@@ -107,7 +107,7 @@ def main(cfg: DictConfig):
             checkpoint_path = ckpt_output_dir / f'delta_step_{global_step + 1}.pt'
             checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
             torch.save({
-                'delta': delta.cpu().state_dict(),
+                'delta': delta.state_dict(),
             }, checkpoint_path)
             logger.info(f'Saved intermediate checkpoint to {checkpoint_path}.')
 


### PR DESCRIPTION
After 100 steps, the delta is transfer to cpu, and the code will meet device mismatch issue subsequently. So change delta.cpu().state_dict() to delta.state_dict() will fix this issue, I test this in both diffusers==0.27.0 and diffusers==0.27.2.